### PR TITLE
BR-3428: add authplug metrics to Grafana provisioned MQTT internals dashboard

### DIFF
--- a/docker/configs/monitoring/grafana/provisioning/dashboards/mqtt-internals.json
+++ b/docker/configs/monitoring/grafana/provisioning/dashboards/mqtt-internals.json
@@ -72,9 +72,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
           "expr": "mqtt_waiting_messages{}",
-          "interval": "",
           "legendFormat": "Waiting messages",
           "refId": "A"
         },
@@ -178,16 +176,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
           "expr": "mqtt_received_messages{}",
-          "interval": "",
           "legendFormat": "Received messages",
           "refId": "A"
         },
         {
-          "exemplar": true,
           "expr": "mqtt_sent_messages{}",
-          "interval": "",
           "legendFormat": "Sent messages",
           "refId": "B"
         }
@@ -282,16 +276,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
           "expr": "mqtt_received_bytes{}",
           "interval": "",
           "legendFormat": "Received bytes",
           "refId": "A"
         },
         {
-          "exemplar": true,
           "expr": "mqtt_sent_bytes{}",
-          "interval": "",
           "legendFormat": "Sent bytes",
           "refId": "B"
         }
@@ -385,9 +376,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
           "expr": "mqtt_active_subscriptions{}",
-          "interval": "",
           "legendFormat": "Active subscriptions",
           "refId": "A"
         }
@@ -483,11 +472,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "exemplar": true,
           "expr": "mqtt_connected_clients{}",
-          "interval": "",
           "legendFormat": "Connected clients",
           "refId": "A"
+        },
+        {
+          "expr": "auth_logins_user_count{}",
+          "legendFormat": "Authorized clients",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -512,6 +504,304 @@
         {
           "decimals": 0,
           "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 24,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "auth_duplicatelist_length{}",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "Duplicatelist",
+          "refId": "A"
+        },
+        {
+          "expr": "auth_blacklist_length{}",
+          "format": "time_series",
+          "legendFormat": "Blacklist",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Attack prevention",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Number of authentication requests against BlueRange server",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 8,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 26,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(auth_server_request_count{}[5m])",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "Authentication requests per 5m",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Authentication requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "A running average of the request/response round-trip time when authenticating with the BlueRange server via REST",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 17,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.1",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "auth_server_request_time{}",
+          "legendFormat": "Response time running average",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Authentication response",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
           "label": null,
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
The Mosquitto MQTT broker preconfigured for use with BlueRange as a docker container now offers metrics supporting in diagnosing the authentication plugin. The metrics provided include number of logins (successful, failed and effective), number and average response time of ACL authentication requests against the BlueRange server, length of duplicate and blacklists. These metrics are serviced under the $SYS/broker/auth/# topic and are exposed at http://host:3000/metrics for (internal) Prometheus scraping.