### PR TITLE
BR-4339: detect docker compose V2 and falling back to V1 otherwise

### DIFF
--- a/docker/bluerange-compose.sh
+++ b/docker/bluerange-compose.sh
@@ -30,7 +30,15 @@ if [ -z "$HOST" ] ; then
   exit 1
 fi
 
-DOCKER_COMPOSE="docker-compose -p ${COMPOSE_PROJECT_NAME} -f docker-compose.yml -f docker-compose.elasticsearch.yml -f docker-compose.mender.yml -f docker-compose.monitoring.yml"
+if docker compose version >/dev/null 2>&1 ; then
+  DOCKER_COMPOSE="docker compose"
+elif docker-compose version >/dev/null 2>&1 ; then
+  DOCKER_COMPOSE="docker-compose"
+else
+  echo "docker compose not present!" >&2
+  exit 1
+fi
+DOCKER_COMPOSE="$DOCKER_COMPOSE -p ${COMPOSE_PROJECT_NAME} -f docker-compose.yml -f docker-compose.elasticsearch.yml -f docker-compose.mender.yml -f docker-compose.monitoring.yml"
 if [ -f "docker-compose.override.yml" ]; then
  DOCKER_COMPOSE="$DOCKER_COMPOSE -f docker-compose.override.yml"
 fi


### PR DESCRIPTION
Support docker compose V2, see also <https://www.docker.com/blog/announcing-compose-v2-general-availability/>.