### PR TITLE
BR-4404: set max_allowed_packet when backing up mariadb…

### DIFF
--- a/docker/bluerange-backup.sh
+++ b/docker/bluerange-backup.sh
@@ -13,6 +13,7 @@ MYSQL_ROOT_PASSWORD=$(./bluerange-compose.sh exec -T database printenv MYSQL_ROO
     --compress \
     --single-transaction \
     --all-databases \
+    --max_allowed_packet=1073741824 \
     >backup/bluerange-${NOW}/mariadb.sql
 
 # backup of mongodb


### PR DESCRIPTION
… as dump may fail for larger BLOBs such as high resolution images.